### PR TITLE
Add repository URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,15 @@
 {
   "name": "@prismatic-io/marketplace",
+  "description": "Embed your prismatic.io integration marketplace within your existing application",
+  "keywords": ["prismatic","marketplace","iPaaS","integration"],
+  "homepage": "https://prismatic.io",
+  "bugs": {
+    "url": "https://github.com/prismatic-io/marketplace"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prismatic-io/marketplace.git"
+  },
   "license": "MIT",
   "version": "3.2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
Our NPM pages should link to our (now) public repo.