### PR TITLE
Add ability to configure trigger detail display in configuration wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prismatic-io/marketplace",
   "license": "MIT",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,12 @@ interface InstanceScreenConfiguration {
   hideTabs?: Array<"Test" | "Executions" | "Monitors" | "Logs">;
 }
 
+type TriggerDetails = "default" | "default-open" | "hidden";
+
 interface ConfigurationWizardConfiguration {
   hideSidebar?: boolean;
   isInModal?: boolean;
+  triggerDetailsConfiguration?: TriggerDetails;
 }
 
 export interface ScreenConfiguration {


### PR DESCRIPTION
Now possible to configure the display of trigger details on the first page of the configuration wizard

Example usage:

```ts
prismatic.init({
  ...configuration,
  screenConfiguration: {
    configurationWizard: {
      triggerDetailsConfiguration: 'default-open'
    }
  }
})
```