### PR TITLE
Marketplace Configuration 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@prismatic-io/marketplace",
   "description": "Embed your prismatic.io integration marketplace within your existing application",
-  "keywords": ["prismatic","marketplace","iPaaS","integration"],
+  "keywords": [
+    "prismatic",
+    "marketplace",
+    "iPaaS",
+    "integration"
+  ],
   "homepage": "https://prismatic.io",
   "bugs": {
     "url": "https://github.com/prismatic-io/marketplace"
@@ -11,7 +16,7 @@
     "url": "https://github.com/prismatic-io/marketplace.git"
   },
   "license": "MIT",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,10 @@ interface InstanceScreenConfiguration {
 
 type TriggerDetails = "default" | "default-open" | "hidden";
 
+interface MarketplaceConfiguration {
+  configuration: "allow-details" | "always-show-details" | "disallow-details";
+}
+
 interface ConfigurationWizardConfiguration {
   hideSidebar?: boolean;
   isInModal?: boolean;
@@ -26,6 +30,7 @@ interface ConfigurationWizardConfiguration {
 export interface ScreenConfiguration {
   instance?: InstanceScreenConfiguration;
   configurationWizard?: ConfigurationWizardConfiguration;
+  marketplace: MarketplaceConfiguration;
 }
 
 interface OptionsBase {

--- a/src/init.ts
+++ b/src/init.ts
@@ -55,7 +55,10 @@ const init = (options?: InitOptions) => {
   closeButtonElement?.addEventListener("click", () => closeDialog());
 
   document.addEventListener("keyup", (e) => {
-    if (e.key === "Escape" && document.querySelector(".pio__modal--is_visible")) {
+    if (
+      e.key === "Escape" &&
+      document.querySelector(".pio__modal--is_visible")
+    ) {
       closeDialog();
     }
   });


### PR DESCRIPTION
Create the ability to configure the marketplace listings page.

### Marketplace Admin stories

**allow-details** (recommended)

- On new instance configuration, **integration card click** activates `summary configure dialog`, allows user to cancel or proceed to `instance configuration dialog`, completion redirects to `marketplace`.
- On existing instance integration, **integration card click** activates `instance configuration dialog`, completion stays on `marketplace`.
- On existing instance integration, **integration card dropdown button** allow user to:
  - button: view details, redirects to `integration summary/details`.
  - button: user level configuration,  activates `user level configure dialog`, completion stays on `marketplace`.
  - button: remove user level configuration (applicable if user level configuration is configured), activates `user level configuration removal dialog`, completion stays on `marketplace`.
  - button: deactivate integration, activates `instance configuration removal dialog`, completion stays on `marketplace`.

**always-show-details**

- On new instance configuration, *integration card click** activates `summary configure dialog`, allows user to cancel or proceed to `instance configuration dialog`, completion redirects to `integration summary/details`.
- On existing instance integration, *integration card click** redirects to `integration summary/details`.

**disallow-details**

- On new instance configuration, *integration card click** activates `summary configure dialog`, allows user to cancel or proceed to `instance configuration dialog`, completion redirects to `marketplace`.
- On existing instance integration, *integration card click**  activates `instance configuration dialog`.

### Marketplace User stories

- On new instance configuration, *integration card click** activates  `user level configuration dialog`, completion redirects to `marketplace`.
- On existing instance integration, *integration card click**  activates to `user level configuration dialog`.
- On existing instance integration, **integration card dropdown button** allow user to:
  - button: remove user level configuration (applicable if user level configuration is configured), activates `user level configuration removal dialog`, completion stays on `marketplace`.