### PR TITLE
Add intellisense prompting for i18n phrases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@prismatic-io/marketplace",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/marketplace",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "14.14.35",
-        "prettier": "2.0.5",
+        "prettier": "2.8.1",
         "ts-loader": "8.0.2",
         "typescript": "4.2.4",
         "webpack": "4.43.0",
@@ -3125,15 +3125,18 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process": {
@@ -7625,9 +7628,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+      "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
       "dev": true
     },
     "process": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/prismatic-io/marketplace.git"
   },
   "license": "MIT",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/node": "14.14.35",
-    "prettier": "2.0.5",
+    "prettier": "2.8.1",
     "ts-loader": "8.0.2",
     "typescript": "4.2.4",
     "webpack": "4.43.0",

--- a/src/phrases.ts
+++ b/src/phrases.ts
@@ -22,275 +22,468 @@ export enum PhraseNamespace {
 
 interface SharedPhrases {
   // common
+  /** English: "Loading" */
   "common.loading": SimplePhrase;
+  /** English: "Saving" */
   "common.saving": SimplePhrase;
+  /** English: "You must be authenticated." */
   "common.unauthorized": SimplePhrase;
 
   // dialogs
+  /** English: "Remove %{removeType}" */
   "deleteDialog.confirmButton": ComplexPhrase<{ removeType: string }>;
+  /** English: "does not match: %{requiredText}" */
   "deleteDialog.confirmRequiredTextValidation": ComplexPhrase<{
     requiredText: string;
   }>;
+  /** English: "To confirm please type" */
   "deleteDialog.confirmText": SimplePhrase;
+  /** English: "Remove %{removeType}" */
   "deleteDialog.openButton": ComplexPhrase<{ removeType: string }>;
+  /** English: "Delete" */
   "deleteDialog.requiredText": SimplePhrase;
+  /** English: "Are you sure?" */
   "deleteDialog.title": SimplePhrase;
+  /** English: "This action cannot be undone. This will permanently delete %{requiredText} %{removalItems}." */
   "deleteDialog.warningText": ComplexPhrase<{
     requiredText: string;
     removalItems?: string;
   }>;
 
+  /** English: "Details" */
   "webhookUrlDialog.openButton": SimplePhrase;
+  /** English: "Webhook URLs" */
   "webhookUrlDialog.title": SimplePhrase;
 
+  /** English: "Remove Integration" */
   "deleteUserConfigurationDialog.confirmButton": SimplePhrase;
+  /** English: "Remove User Configuration" */
   "deleteUserConfigurationDialog.confirmButton--isAdmin": SimplePhrase;
+  /** English: "Delete" */
   "deleteUserConfigurationDialog.openButton": SimplePhrase;
+  /** English: "Are you sure?" */
   "deleteUserConfigurationDialog.title": SimplePhrase;
+  /** English: "This action cannot be undone. This will permanently delete the integration." */
   "deleteUserConfigurationDialog.warningText": SimplePhrase;
+  /** English: "This action cannot be undone. This will permanently delete the configuration for %{email}." */
   "deleteUserConfigurationDialog.warningText--isAdmin": ComplexPhrase<{
     email: string;
   }>;
 
+  /** English: "Deactivate Integration" */
   "deactivateIntegrationDialog.confirmButton": SimplePhrase;
+  /** English: "Deactivate Integration" */
   "deactivateIntegrationDialog.openButton": SimplePhrase;
+  /** English: "Are you sure?" */
   "deactivateIntegrationDialog.title": SimplePhrase;
+  /** English: "This will deactivate this integration." */
   "deactivateIntegrationDialog.warningText": SimplePhrase;
 
+  /** English: "Cancel" */
   "configurationWizardDialog.cancelButton": SimplePhrase;
+  /** English: "Finish" */
   "configurationWizardDialog.finishButton": SimplePhrase;
+  /** English: "Next" */
   "configurationWizardDialog.nextButton": SimplePhrase;
+  /** English: "Previous" */
   "configurationWizardDialog.previousButton": SimplePhrase;
+  /** English: "Returning to the previous page will discard unsaved changes on this page. Are you sure?" */
   "configurationWizardDialog.previousWarningText": SimplePhrase;
 
+  /** English: "Cancel" */
   "apiKeyDialog.cancelButton": SimplePhrase;
+  /** English: "Generate API key" */
   "apiKeyDialog.generateApiKeyButton": SimplePhrase;
+  /** English: "This will remove the existing API Key." */
   "apiKeyDialog.text": SimplePhrase;
+  /** English: "API key" */
   "apiKeyDialog.title": SimplePhrase;
+  /** English: "Update" */
   "apiKeyDialog.updateButton": SimplePhrase;
 
-  "activateIntegrationDialog.banner.text--isNotConfigurable": ComplexPhrase<{ organization?: string }>;
+  /** English: "Please contact %{organization} to configure this integration." */
+  "activateIntegrationDialog.banner.text--isNotConfigurable": ComplexPhrase<{
+    organization?: string;
+  }>;
+  /** English: "Cancel" */
   "activateIntegrationDialog.cancelButton": SimplePhrase;
+  /** English: "Configure" */
   "activateIntegrationDialog.configureButton": SimplePhrase;
 
   // filter bar
+  /** English: "Integration Marketplace" */
   "filterBar.breadcrumb.integrationMarketplace": SimplePhrase;
+  /** English: "Active Integrations" */
   "filterBar.breadcrumb.activeIntegrations": SimplePhrase;
+  /** English: "Filter" */
   "filterBar.openFiltersButton": SimplePhrase;
+  /** English: "Clear filters" */
   "filterBar.clearFiltersButton": SimplePhrase;
+  /** English: "[Empty String]" */
   "filterBar.title": SimplePhrase;
 
   // filter results
+  /** English: "[Empty String]" */
   "filterResults.placeholderCta": SimplePhrase;
+  /** English: "[Empty String]" */
   "filterResults.placeholderText": SimplePhrase;
+  /** English: "[Empty String]" */
   "filterResults.placeholderTitle": SimplePhrase;
 
   // inputs
+  /** English: "Monitor" */
   "input.alertMonitor": SimplePhrase;
+  /** English: "Alert Trigger" */
   "input.alertTriggerLabel": SimplePhrase;
+  /** English: "Add API key" */
   "input.apiKeyAddButton": SimplePhrase;
+  /** English: "API Key" */
   "input.apiKeyLabel": SimplePhrase;
+  /** English: "No API key configured" */
   "input.apiKeyPlaceholder": SimplePhrase;
+  /** English: "Category" */
   "input.categoryLabel": SimplePhrase;
+  /** English: "Confirmation text" */
   "input.confirmRequiredTextLabel": SimplePhrase;
+  /** English: "Content type" */
   "input.contentTypeLabel": SimplePhrase;
+  /** English: "Customer" */
   "input.customerLabel": SimplePhrase;
+  /** English: "Email" */
   "input.emailLabel": SimplePhrase;
+  /** English: "End Date/Time" */
   "input.endDateLabel": SimplePhrase;
+  /** English: "External ID" */
   "input.externalIdLabel": SimplePhrase;
+  /** English: "Search %{type}" */
   "input.filterSearchPlaceholder": ComplexPhrase<{ type?: string }>;
+  /** English: "Add header" */
   "input.headersAddButton": SimplePhrase;
+  /** English: "Key" */
   "input.headersKeyLabel": SimplePhrase;
+  /** English: "Headers" */
   "input.headersLabel": SimplePhrase;
+  /** English: "Value" */
   "input.headersValueLabel": SimplePhrase;
+  /** English: "Instance" */
   "input.instanceLabel": SimplePhrase;
+  /** English: "Integration" */
   "input.integrationLabel": SimplePhrase;
+  /** English: "Integration Version" */
   "input.integrationVersionLabel": SimplePhrase;
+  /** English: "Designer Version" */
   "input.integrationVersionLatestLabel": SimplePhrase;
+  /** English: "Designer Version" */
   "input.latestVersionLabel": SimplePhrase;
+  /** English: "Log Severity" */
   "input.logSeverityLabel": SimplePhrase;
+  /** English: "Connection Only" */
   "input.logType.integrationConnectionValue": SimplePhrase;
+  /** English: "Execution & Connection" */
   "input.logType.integrationExecutionAndConnectionValue": SimplePhrase;
+  /** English: "Execution only" */
   "input.logType.integrationExecutionValue": SimplePhrase;
+  /** English: "Log Type" */
   "input.logTypeLabel": SimplePhrase;
+  /** English: "No options found" */
   "input.noOptionsValue": SimplePhrase;
+  /** English: "None" */
   "input.noneValue": SimplePhrase;
+  /** English: "Show original executions only" */
   "input.originalOnlyLabel": SimplePhrase;
+  /** English: "Payload body" */
   "input.payloadBodyLabel": SimplePhrase;
+  /** English: "Post URL" */
   "input.postUrlLabel": SimplePhrase;
+  /** English: "Role" */
   "input.roleLabel": SimplePhrase;
+  /** English: "Flow Selector" */
   "input.selectFlowLabel": SimplePhrase;
+  /** English: "Log severity" */
   "input.severityLabel": SimplePhrase;
+  /** English: "Start Date/Time" */
   "input.startDateLabel": SimplePhrase;
+  /** English: "Failed" */
   "input.status.failedValue": SimplePhrase;
+  /** English: "Running" */
   "input.status.runningValue": SimplePhrase;
+  /** English: "Successful" */
   "input.status.successfulValue": SimplePhrase;
+  /** English: "Status" */
   "input.statusLabel": SimplePhrase;
+  /** English: "Step" */
   "input.stepLabel": SimplePhrase;
+  /** English: "URL" */
   "input.urlLabel": SimplePhrase;
 
   // details
+  /** English: "Category" */
   "detail.categoryLabel": SimplePhrase;
+  /** English: "Config Variable" */
   "detail.configVariableLabel": SimplePhrase;
+  /** English: "Customer" */
   "detail.customerLabel": SimplePhrase;
+  /** English: "Description" */
   "detail.descriptionLabel": SimplePhrase;
+  /** English: "Execution" */
   "detail.executionLabel": SimplePhrase;
+  /** English: "View in Execution Context" */
   "detail.executionText": SimplePhrase;
+  /** English: "Instance" */
   "detail.instanceLabel": SimplePhrase;
+  /** English: "Integration" */
   "detail.integrationLabel": SimplePhrase;
+  /** English: "Overview" */
   "detail.overviewLabel": SimplePhrase;
+  /** English: "Show more..." */
   "detail.retryButton": SimplePhrase;
+  /** English: "Retry" */
   "detail.retryLabel": SimplePhrase;
+  /** English: "%{retryCount} retries of %{maxRetryCount} total." */
   "detail.retryValue": ComplexPhrase<{
     retryCount: number;
     maxRetryCount: number;
   }>;
+  /** English: "Status" */
   "detail.statusLabel": SimplePhrase;
+  /** English: "Paused" */
   "detail.statusPausedValue": SimplePhrase;
+  /** English: "Running" */
   "detail.statusRunningValue": SimplePhrase;
+  /** English: "Activated but not configured" */
   "detail.statusUnconfiguredValue": SimplePhrase;
+  /** English: "Version" */
   "detail.versionLabel": SimplePhrase;
 
   // data table
+  /** English: "Connection" */
   "dataTable.connectionLabel": SimplePhrase;
+  /** English: "Customer" */
   "dataTable.customerLabel": SimplePhrase;
+  /** English: "Email" */
   "dataTable.emailLabel": SimplePhrase;
+  /** English: "Events" */
   "dataTable.eventsLabel": SimplePhrase;
+  /** English: "Flow" */
   "dataTable.flowLabel": SimplePhrase;
+  /** English: "Instance" */
   "dataTable.instanceLabel": SimplePhrase;
+  /** English: "Integration" */
   "dataTable.integrationLabel": SimplePhrase;
+  /** English: "Last triggered" */
   "dataTable.lastTriggeredAtLabel": SimplePhrase;
+  /** English: "Message" */
   "dataTable.messageLabel": SimplePhrase;
+  /** English: "Name" */
   "dataTable.nameLabel": SimplePhrase;
+  /** English: "Timestamp" */
   "dataTable.timestampLabel": SimplePhrase;
+  /** English: "Triggers" */
   "dataTable.triggersLabel": SimplePhrase;
 
   // tooltips
+  /** English: "Close" */
   "tooltip.close": SimplePhrase;
+  /** English: "Copied to clipboard!" */
   "tooltip.copyConfirmed": SimplePhrase;
+  /** English: "Copy cURL to clipboard" */
   "tooltip.copyCurl": SimplePhrase;
+  /** English: "Copy log to clipboard" */
   "tooltip.copyLog": SimplePhrase;
+  /** English: "Copy payload to clipboard" */
   "tooltip.copyPayload": SimplePhrase;
+  /** English: "Copy URL to clipboard" */
   "tooltip.copyUrl": SimplePhrase;
+  /** English: "Pass this API key via an HTTP header" */
   "tooltip.passApiKeyToHeader": SimplePhrase;
+  /** English: "Restore default" */
   "tooltip.restoreDefault": SimplePhrase;
 
   // log severity levels
+  /** English: "Debug" */
   "logSeverity.debug": SimplePhrase;
+  /** English: "Error" */
   "logSeverity.error": SimplePhrase;
+  /** English: "Fatal" */
   "logSeverity.fatal": SimplePhrase;
+  /** English: "Info" */
   "logSeverity.info": SimplePhrase;
+  /** English: "Metric" */
   "logSeverity.metric": SimplePhrase;
+  /** English: "Trace" */
   "logSeverity.trace": SimplePhrase;
+  /** English: "Warn" */
   "logSeverity.warn": SimplePhrase;
 
   // tabs
+  /** English: "Monitors" */
   "alertMonitorsTab.title": SimplePhrase;
+  /** English: "User Configuration" */
   "configurationTab.title": SimplePhrase;
+  /** English: "Executions" */
   "executionsTab.title": SimplePhrase;
+  /** English: "Payload" */
   "payloadTab.title": SimplePhrase;
+  /** English: "Summary" */
   "summaryTab.title": SimplePhrase;
 
+  /** English: "Test is running" */
   "testTab.testResults.banner.text--testIsRunning": SimplePhrase;
+  /** English: "View Execution" */
   "testTab.testResults.button": SimplePhrase;
+  /** English: "Endpoint test result" */
   "testTab.testResults.title": SimplePhrase;
+  /** English: "Test" */
   "testTab.title": SimplePhrase;
 
+  /** English: "Result preview not available for this step" */
   "stepOutputsTab.noResultsText": SimplePhrase;
+  /** English: "No step outputs available" */
   "stepOutputsTab.noStepOutputsText": SimplePhrase;
+  /** English: "Step Not Available" */
   "stepOutputsTab.stepNotSelected": SimplePhrase;
+  /** English: "Step Outputs" */
   "stepOutputsTab.title": SimplePhrase;
 
+  /** English: "Error" */
   "logsTab.banner.error": ComplexPhrase<{ count: number }>;
+  /** English: "Errors" */
   "logsTab.banner.errorPlural": ComplexPhrase<{ count: number }>;
+  /** English: "No logs available" */
   "logsTab.noLogsTitle": SimplePhrase;
+  /** English: "Select a test run to view test logs" */
   "logsTab.noTestSelectedText": SimplePhrase;
+  /** English: "No test run selected" */
   "logsTab.noTestSelectedTitle": SimplePhrase;
+  /** English: "Show all logs" */
   "logsTab.showAllButton": SimplePhrase;
+  /** English: "Show only errors" */
   "logsTab.showErrorsButton": SimplePhrase;
+  /** English: "Logs" */
   "logsTab.title": SimplePhrase;
 
+  /** English: "Cancelled by a new execution" */
   "retryTab.cancelledLabel": SimplePhrase;
+  /** English: "Next retry" */
   "retryTab.scheduledRetryLabel": SimplePhrase;
+  /** English: "%{retryIndex} of %{maxRetryCount} at %{nextScheduledRetry}" */
   "retryTab.scheduledRetryText": ComplexPhrase<{
     retryIndex: number;
     maxRetryCount: number;
     nextScheduledRetry: string;
   }>;
+  /** English: "Failed after %{retryCount} retries" */
   "retryTab.statusFailedPluralText": ComplexPhrase<{ retryCount: number }>;
+  /** English: "Failed after %{retryCount} retry" */
   "retryTab.statusFailedText": ComplexPhrase<{ retryCount: number }>;
+  /** English: "Final status" */
   "retryTab.statusLabel": SimplePhrase;
+  /** English: "Succeeded on retry %{retryCount}" */
   "retryTab.statusSuccessText": ComplexPhrase<{ retryCount: number }>;
+  /** English: "Retry" */
   "retryTab.title": SimplePhrase;
 
   // components
+  /** English: "Trigger details" */
   "triggerDetails.title": SimplePhrase;
+  /** English: "API key configured" */
   "triggerDetails.apiConfiguredText": SimplePhrase;
+  /** English: "No API key configured" */
   "triggerDetails.noApiConfiguredText": SimplePhrase;
-
+  /** English: "Execution Details" */
   "executionDetails.title": SimplePhrase;
-
+  /** English: "Executions" */
   "executionOptions.title": SimplePhrase;
 }
 
 export interface UniquePhrases {
   // marketplace listing
+  /** English: "Activated but not configured" */
   "integration-marketplace__card.activateLabel": SimplePhrase;
+  /** English: "Paused" */
   "integration-marketplace__card.pausedLabel": SimplePhrase;
+  /** English: "Activated" */
   "integration-marketplace__card.runningLabel": SimplePhrase;
+  /** English: "Activated but not configured" */
   "integration-marketplace__card.ulcUnconfiguredLabel": SimplePhrase;
+  /** English: "Activated" */
   "integration-marketplace__filterBar.activateButton": SimplePhrase;
+  /** English: "All" */
   "integration-marketplace__filterBar.allButton": SimplePhrase;
 
   // marketplace integration summary
+  /** English: "Please contact %{organization} to activate this integration." */
   "integrations.id__banner.customerActivateText": ComplexPhrase<{
     organization: string;
   }>;
+  /** English: "Please contact %{organization} to update to latest version." */
   "integrations.id__banner.customerUpdateText": ComplexPhrase<{
     organization: string;
   }>;
+  /** English: "Your integration is enabled" */
   "integrations.id__banner.enabledText": SimplePhrase;
+  /** English: "Pause Integration" */
   "integrations.id__banner.pauseButton": SimplePhrase;
+  /** English: "Your integration is paused" */
   "integrations.id__banner.pausedText": SimplePhrase;
+  /** English: "Unpause Integration" */
   "integrations.id__banner.unpauseButton": SimplePhrase;
+  /** English: "Update" */
   "integrations.id__banner.updateButton": SimplePhrase;
+  /** English: "There is an update available" */
   "integrations.id__banner.updateText": SimplePhrase;
+  /** English: "Configure User Level Configuration" */
   "integrations.id__filterBar.configureUserButton": SimplePhrase;
+  /** English: "Reconfigure" */
   "integrations.id__filterBar.reconfigureButton": SimplePhrase;
+  /** English: "Reconfigure User Level Configuration" */
   "integrations.id__filterBar.reconfigureUserButton": SimplePhrase;
+  /** English: "View Configuration" */
   "integrations.id__filterBar.viewConfigurationButton": SimplePhrase;
+  /** English: "View User Level Configuration" */
   "integrations.id__filterBar.viewUserConfigurationButton": SimplePhrase;
 
   // marketplace integration summary
+  /** English: "Save & Run Test" */
   "integrations.id.test__filterBar.saveRunButton": SimplePhrase;
 
   // marketplace integration alert monitors
+  /** English: "Click the add monitor button to add a monitor." */
   "integrations.id.alert-monitors__filterResults.placeholderText--hasInstanceOrCustomer": SimplePhrase;
 
   // marketplace integration logs
+  /** English: "Go to instances" */
   "integrations.id.logs__filterResults.placeholderCta--hasCustomer": SimplePhrase;
+  /** English: "To add logs, first start an instance." */
   "integrations.id.logs__filterResults.placeholderText--hasCustomer": SimplePhrase;
+  /** English: "To add logs, make sure your instance is running." */
   "integrations.id.logs__filterResults.placeholderText--hasInstance": SimplePhrase;
+  /** English: "Refresh logs" */
   "integrations.id.logs__filterBar.refreshButton": SimplePhrase;
+  /** English: "Polling is only available with default filters." */
   "integrations.id.logs__filterBar.refreshTooltip": SimplePhrase;
 
   // marketplace not found
+  /** English: "Not Found" */
   "app.marketplace-not-found__title": SimplePhrase;
+  /** English: "The page you requested was not found." */
   "app.marketplace-not-found__text": SimplePhrase;
 
   // 404
+  /** English: "404" */
   "404__title": SimplePhrase;
+  /** English: "The page you requested was not found." */
   "404__text": SimplePhrase;
+  /** English: "Back to %{screen}" */
   "404__button": ComplexPhrase<{ screen: string }>;
 }
 
 export type PhrasesBase = SharedPhrases & UniquePhrases;
 
-export type PrismaticPhrases<T extends SharedPhrases = SharedPhrases> = Partial<
-  {
+export type PrismaticPhrases<T extends SharedPhrases = SharedPhrases> =
+  Partial<{
     [K in keyof T as `${PhraseNamespace}__${string & K}`]: T[K];
-  }
-> &
-  PhrasesBase;
+  }> &
+    PhrasesBase;
 
 export type Phrases = Partial<PrismaticPhrases>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "declaration": true,
-    "removeComments": true,
+    "removeComments": false,
     "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
This adds the English translations to each i18n phrase as a typedoc comment, so it shows up in intellisense in a code editor. This makes it easier to figure out how phrases should be translated.

<img width="1140" alt="Screen Shot 2022-12-19 at 9 02 15 AM" src="https://user-images.githubusercontent.com/3622586/208455977-15ce8bee-7928-4837-a375-711d36e553d4.png">

This also bumps `prettier` so it can handle `Partial` definitions with more grace.