### PR TITLE
screenConfiguration options set at .showMarketplace should inherit from .init options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.4.5",
       "license": "MIT",
       "dependencies": {
-        "lodash": "4.17.21"
+        "lodash.merge": "4.6.2"
       },
       "devDependencies": {
         "@types/node": "18.11.17",
@@ -863,10 +863,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2209,10 +2209,10 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "@prismatic-io/marketplace",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/marketplace",
-      "version": "3.4.4",
+      "version": "3.4.5",
       "license": "MIT",
+      "dependencies": {
+        "lodash": "4.17.21"
+      },
       "devDependencies": {
         "@types/node": "18.11.17",
         "prettier": "2.8.1",
@@ -859,6 +862,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -2200,6 +2208,11 @@
       "requires": {
         "p-locate": "^4.1.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/prismatic-io/marketplace.git"
   },
   "license": "MIT",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -37,5 +37,8 @@
     "typescript": "4.9.4",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1"
+  },
+  "dependencies": {
+    "lodash": "4.17.21"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "webpack-cli": "5.0.1"
   },
   "dependencies": {
-    "lodash": "4.17.21"
+    "lodash.merge": "4.6.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import init from "./init";
 import authenticate from "./authenticate";
 import { modalSelector, iframeContainerSelector } from "./selectors";
@@ -151,7 +152,11 @@ const setIframe = (
   if (options) {
     Object.entries(options).forEach(([key, value]) => {
       if (key in state) {
-        state[key] = value;
+        if (state[key] instanceof Object) {
+          state[key] = _.merge(state[key], value);
+        } else {
+          state[key] = value;
+        }
       }
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,9 @@ interface MarketplaceConfiguration {
 }
 
 interface InitializingConfiguration {
+  /** The background color of the loading screen */
   background: string;
+  /** The font color of the loading screen text and loading icon */
   color: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import merge from "lodash.merge";
 import init from "./init";
 import authenticate from "./authenticate";
 import { modalSelector, iframeContainerSelector } from "./selectors";
@@ -155,7 +155,7 @@ const setIframe = (
     Object.entries(options).forEach(([key, value]) => {
       if (key in state) {
         if (state[key] instanceof Object) {
-          state[key] = _.merge(state[key], value);
+          state[key] = merge(state[key], value);
         } else {
           state[key] = value;
         }


### PR DESCRIPTION
Currently, if you set `screenConfiguration` settings on `.showMarketplace()`, those completely overwrite those settings set at `.init()`. This merges the options instead, so you can set, say, `screenConfiguration.initializing` at the `.init()` level, and `screenConfiguration.configurationWizard` at the `.showMarketplace()` level, without losing `screenConfiguration.initializing`.