### PR TITLE
Add status to connection config vars, showing active, error or pending

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -45,8 +45,15 @@ export type DefaultConfigVar =
   | ValueListConfigVar
   | KeyValueListConfigVar;
 
+export enum InstanceConfigVariableStatus {
+  ACTIVE = "ACTIVE",
+  ERROR = "ERROR",
+  PENDING = "PENDING",
+}
+
 export interface ConnectionConfigVar {
   inputs: Record<string, { value: string }>;
+  status: InstanceConfigVariableStatus | null;
 }
 
 export type ConfigVar = DefaultConfigVar | ConnectionConfigVar;


### PR DESCRIPTION
This will allow a `INSTANCE_CONFIGURATION_LOADED` events to show connection config var status alongside current input values.