### PR TITLE
Add ability to run a graphql request to Prismatic as a customer user from embedded marketplace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/marketplace",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/marketplace",
-      "version": "3.4.3",
+      "version": "3.4.4",
       "license": "MIT",
       "dependencies": {
         "lodash.merge": "4.6.2"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/prismatic-io/marketplace.git"
   },
   "license": "MIT",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/graphqlRequest.ts
+++ b/src/graphqlRequest.ts
@@ -1,0 +1,24 @@
+import { state, assertInit } from "./index";
+
+export interface RequestProps {
+  query: string;
+  variables?: Record<string, unknown>;
+}
+
+export const graphqlRequest = async ({ query, variables }: RequestProps) => {
+  assertInit("authenticate");
+
+  const { jwt: accessToken, prismaticUrl } = state;
+
+  const response = await fetch(`${prismaticUrl}/api`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  return await response.json();
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   PrismaticMessageEvent,
   setConfigVars,
 } from "./events";
+import { graphqlRequest } from "./graphqlRequest";
 
 type Theme = "DARK" | "LIGHT";
 
@@ -274,6 +275,8 @@ export const close = () => {
 
 export { authenticate, init };
 
+export { graphqlRequest };
+
 export { rootElementId, modalSelector } from "./selectors";
 
 export {
@@ -295,4 +298,5 @@ export default {
   configureIntegration,
   close,
   setConfigVars,
+  graphqlRequest,
 };


### PR DESCRIPTION
This PR adds a function, `graphqlRequest`, that makes a request to the Prismatic API using the customer's JWT. This will allow customers to query for available integrations, instances, etc, and developers to present those results as custom UI elements to their users.