### PR TITLE
Use url-join to join Prismatic base URL with /api or /embedded/authenticate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@prismatic-io/marketplace",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/marketplace",
-      "version": "3.4.4",
+      "version": "3.4.5",
       "license": "MIT",
       "dependencies": {
-        "lodash.merge": "4.6.2"
+        "lodash.merge": "4.6.2",
+        "url-join": "5.0.0"
       },
       "devDependencies": {
         "@types/node": "18.11.17",
@@ -1383,6 +1384,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -2551,6 +2560,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "url-join": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="
     },
     "watchpack": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/prismatic-io/marketplace.git"
   },
   "license": "MIT",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -39,6 +39,7 @@
     "webpack-cli": "5.0.1"
   },
   "dependencies": {
-    "lodash.merge": "4.6.2"
+    "lodash.merge": "4.6.2",
+    "url-join": "5.0.0"
   }
 }

--- a/src/authenticate.ts
+++ b/src/authenticate.ts
@@ -1,3 +1,4 @@
+import urlJoin from "url-join";
 import { state, assertInit } from "./index";
 
 export interface AuthenticateProps {
@@ -29,12 +30,15 @@ const authenticate = async (props: AuthenticateProps) => {
 
   const prismaticUrl = props.prismaticUrl ?? state.prismaticUrl;
 
-  const authResponse = await fetch(`${prismaticUrl}/embedded/authenticate`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    method: "post",
-  });
+  const authResponse = await fetch(
+    urlJoin(prismaticUrl, "embedded", "authenticate"),
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      method: "post",
+    }
+  );
 
   if (!authResponse.ok) {
     const responseText = await authResponse.text();

--- a/src/graphqlRequest.ts
+++ b/src/graphqlRequest.ts
@@ -1,3 +1,4 @@
+import urlJoin from "url-join";
 import { state, assertInit } from "./index";
 
 export interface RequestProps {
@@ -10,7 +11,7 @@ export const graphqlRequest = async ({ query, variables }: RequestProps) => {
 
   const { jwt: accessToken, prismaticUrl } = state;
 
-  const response = await fetch(`${prismaticUrl}/api`, {
+  const response = await fetch(urlJoin(prismaticUrl, "api"), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export interface StateProps {
   initComplete: boolean;
   jwt: string;
   translation?: Translation;
-  prismaticUrl?: string;
+  prismaticUrl: string;
   screenConfiguration?: ScreenConfiguration;
   theme?: Theme;
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -3,11 +3,8 @@ import headStyles from "./headStyles";
 import { rootElementId, modalSelector } from "./selectors";
 
 export interface InitOptions
-  extends Pick<
-      StateProps,
-      "screenConfiguration" | "prismaticUrl" | "theme" | "translation"
-    >,
-    Partial<Pick<StateProps, "filters">> {}
+  extends Pick<StateProps, "screenConfiguration" | "theme" | "translation">,
+    Partial<Pick<StateProps, "filters" | "prismaticUrl">> {}
 
 const init = (options?: InitOptions) => {
   const existingElement = document.getElementById(rootElementId);


### PR DESCRIPTION
Currently, if a developer specifies a white-labeled domain with a trailing slash (e.g. `https://integrations.example.com/`), the call to authenticate is sent to `https://integrations.example.com//embedded/authenticate` with a double-`/` because we're concatenating strings together. That call fails.

This leverages [url-join](https://www.npmjs.com/package/url-join) to ensure that we can handle trailing slashes. Whether or not you have a trailing slash, `urlJoin(prismaticUrl, "embedded", "authenticate")` will evaluate to the expected `https://integrations.example.com/embedded/authenticate`.